### PR TITLE
fix: only execute plugin if it exists, also allow cobra built-in commands to execute

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,8 +18,11 @@ package main
 
 import (
 	"github.com/konveyor/cli/cmd"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		logrus.Fatalf("Error: %q", err)
+	}
 }


### PR DESCRIPTION
Also pass the environment variables to the plugin.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>